### PR TITLE
Feature: Implement Web Profile View Fragment and Enhancements

### DIFF
--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -3,6 +3,19 @@
   <component name="AndroidTestResultsUserPreferences">
     <option name="androidTestResultsTableState">
       <map>
+        <entry key="-2127506304">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Tests" value="360" />
+                  <entry key="Xiaomi M2010J19CG" value="120" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="-2069268370">
           <value>
             <AndroidTestResultsTableState>
@@ -17,6 +30,19 @@
           </value>
         </entry>
         <entry key="-2042611730">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Tests" value="360" />
+                  <entry key="Xiaomi M2010J19CG" value="120" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="-1642872770">
           <value>
             <AndroidTestResultsTableState>
               <option name="preferredColumnWidths">
@@ -225,6 +251,19 @@
           </value>
         </entry>
         <entry key="-396540332">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Tests" value="360" />
+                  <entry key="Xiaomi M2010J19CG" value="120" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="-271593941">
           <value>
             <AndroidTestResultsTableState>
               <option name="preferredColumnWidths">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     def android_material_version = "1.10.0"
     def constraintlayout_version = "2.1.4"
     def recyclerview_version = "1.3.2"
-    def androidx_window_version = "1.1.0"
+    def androidx_window_version = '1.2.0'
     def androidx_preference_version = "1.2.1"
     def androidx_core_ktx_version = "1.12.0"
     def androidx_appcompat_version = "1.6.1"

--- a/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/ui/fragments/favourites/FavouritesFragmentTest.kt
+++ b/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/ui/fragments/favourites/FavouritesFragmentTest.kt
@@ -69,11 +69,11 @@ class FavouritesFragmentTest {
 
             onView(withId(R.id.dialogMainLayout))
                 .check(matches(isDisplayed()))
-            onView(ViewMatchers.withText(R.string.yes)).perform(click())
+            onView(withId(R.id.buttonYes)).perform(click())
 
             onView(withId(R.id.dialogMainLayout))
                 .check(matches(isDisplayed()))
-            onView(ViewMatchers.withText(R.string.ok)).perform(click())
+            onView(withId(R.id.button)).perform(click())
 
             // Press the back button
             Espresso.pressBack()

--- a/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/ui/fragments/home/HomeFragmentTest.kt
+++ b/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/ui/fragments/home/HomeFragmentTest.kt
@@ -107,6 +107,7 @@ class HomeFragmentTest {
 
         // Click on the search button
         onView(withId(R.id.searchInputText)).perform(pressImeActionButton())
+        Thread.sleep(2000)
 
         // Check if an error message is displayed
         onView(

--- a/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/ui/fragments/settings/SettingsFragmentTest.kt
+++ b/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/ui/fragments/settings/SettingsFragmentTest.kt
@@ -33,12 +33,12 @@ class SettingsFragmentTest{
         MockitoAnnotations.initMocks(this)
         viewModel = SettingsViewModel()
         // Navigate to HomeFragment before each test
-        onView(withId(R.id.homeFragment)).perform(ViewActions.click())
+        onView(withId(R.id.homeFragment)).perform(click())
     }
 
     @Test
     fun testNavigateToSettingsPage(){
-        onView(withId(R.id.settingsFragment)).perform(ViewActions.click())
+        onView(withId(R.id.settingsFragment)).perform(click())
         onView(withId(R.id.settingsFragment)).check(
             matches(
                 isDisplayed()
@@ -48,7 +48,7 @@ class SettingsFragmentTest{
 
     @Test
     fun testAllElementsAvailable(){
-        onView(withId(R.id.settingsFragment)).perform(ViewActions.click())
+        onView(withId(R.id.settingsFragment)).perform(click())
         onView(withId(R.id.settingsFragment)).check(
             matches(
                 isDisplayed()
@@ -65,7 +65,7 @@ class SettingsFragmentTest{
 
     @Test
     fun testDefaultLanguageIsEnglish(){
-        onView(withId(R.id.settingsFragment)).perform(ViewActions.click())
+        onView(withId(R.id.settingsFragment)).perform(click())
         onView(withId(R.id.settingsFragment)).check(
             matches(
                 isDisplayed()
@@ -79,7 +79,7 @@ class SettingsFragmentTest{
 
     @Test
     fun testEnglishSelected(){
-        onView(withId(R.id.settingsFragment)).perform(ViewActions.click())
+        onView(withId(R.id.settingsFragment)).perform(click())
         onView(withId(R.id.settingsFragment)).check(
             matches(
                 isDisplayed()
@@ -110,7 +110,7 @@ class SettingsFragmentTest{
 
     @Test
     fun testJapaneseSelected(){
-        onView(withId(R.id.settingsFragment)).perform(ViewActions.click())
+        onView(withId(R.id.settingsFragment)).perform(click())
         onView(withId(R.id.settingsFragment)).check(
             matches(
                 isDisplayed()
@@ -140,7 +140,7 @@ class SettingsFragmentTest{
 
     @Test
     fun testSetRadioButtonsAccordingToSelectedLanguage(){
-        onView(withId(R.id.settingsFragment)).perform(ViewActions.click())
+        onView(withId(R.id.settingsFragment)).perform(click())
         onView(withId(R.id.settingsFragment)).check(
             matches(
                 isDisplayed()

--- a/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/ui/fragments/webprofileview/WebProfileViewFragmentTest.kt
+++ b/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/ui/fragments/webprofileview/WebProfileViewFragmentTest.kt
@@ -1,0 +1,78 @@
+package jp.co.yumemi.android.code_check.ui.fragments.webprofileview
+
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.assertion.ViewAssertions
+import androidx.test.espresso.contrib.RecyclerViewActions
+import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import jp.co.yumemi.android.code_check.R
+import jp.co.yumemi.android.code_check.ui.activities.MainActivity
+import jp.co.yumemi.android.code_check.ui.fragments.home.RepoListAdapter
+import jp.co.yumemi.android.code_check.utils.LocalHelper
+import jp.co.yumemi.android.code_check.utils.NetworkUtils
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class WebProfileViewFragmentTest{
+    @get:Rule
+    val activityRule = ActivityScenarioRule(MainActivity::class.java)
+
+    private lateinit var mainActivity: MainActivity
+
+    @Before
+    fun setUp() {
+        // Navigate to HomeFragment before each test
+        Espresso.onView(withId(R.id.homeFragment)).perform(ViewActions.click())
+        activityRule.scenario.onActivity { activity ->
+            mainActivity = activity
+        }
+    }
+
+    @Test
+    fun testWebPageLoad() {
+        // Type a valid search query in the search view
+        Espresso.onView(withId(R.id.searchInputText))
+            .perform(ViewActions.typeText("Android"))
+
+        if (NetworkUtils.isNetworkAvailable()) {
+            // Click on the search button
+            Espresso.onView(withId(R.id.searchInputText))
+                .perform(ViewActions.pressImeActionButton())
+            Thread.sleep(5000)
+            Espresso.onView(withId(R.id.recyclerView))
+                .check(ViewAssertions.matches(ViewMatchers.isDisplayed())).perform(
+                    RecyclerViewActions.actionOnItemAtPosition<RepoListAdapter.RepoListViewHolder>(
+                        0,
+                        ViewActions.click()
+                    )
+                )
+            // Verify that the RepositoryFragment is launched
+            Espresso.onView(withId(R.id.btnMore))
+                .check(ViewAssertions.matches(ViewMatchers.isDisplayed())).perform(ViewActions.click())
+            Espresso.onView(withId(R.id.webView))
+                .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+        } else {
+            // Click on the search button
+            Espresso.onView(withId(R.id.searchInputText))
+                .perform(ViewActions.pressImeActionButton())
+            // Check if the error dialog is displayed
+            Espresso.onView(
+                ViewMatchers.withText(
+                    LocalHelper.getString(
+                        mainActivity,
+                        R.string.no_internet
+                    )
+                )
+            )
+                .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+        }
+    }
+
+}

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/constants/StringConstants.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/constants/StringConstants.kt
@@ -40,4 +40,9 @@ object StringConstants {
      * Tag for the Account Details Fragment.
      */
     const val ACCOUNT_DETAILS_FRAGMENT = "ACCOUNT DETAILS FRAGMENT"
+
+    /**
+     * Tag for the Git Hub Profile View Fragment.
+     */
+    const val WEB_PROFILE_VIEW_FRAGMENT = "WEB PROFILE VIEW FRAGMENT"
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/db/GitHubObjectsDatabase.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/db/GitHubObjectsDatabase.kt
@@ -2,6 +2,9 @@ package jp.co.yumemi.android.code_check.db
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+import jp.co.yumemi.android.code_check.constants.StringConstants
 import jp.co.yumemi.android.code_check.models.LocalGitHubRepoObject
 
 /**
@@ -11,7 +14,7 @@ import jp.co.yumemi.android.code_check.models.LocalGitHubRepoObject
  * @param entities An array of entity classes that define the structure of the database.
  * @param version The version of the database schema. Incrementing this number triggers a database migration.
  */
-@Database(entities = [LocalGitHubRepoObject::class], version = 2)
+@Database(entities = [LocalGitHubRepoObject::class], version = 3)
 abstract class GitHubObjectsDatabase : RoomDatabase() {
     /**
      * Returns a Data Access Object (DAO) for interacting with the GitHub repository objects stored in the database.
@@ -19,4 +22,17 @@ abstract class GitHubObjectsDatabase : RoomDatabase() {
      * @return An instance of [GitHubObjectDao] for performing database operations on GitHub repository data.
      */
     abstract fun gitHubObjectDao(): GitHubObjectDao
+
+    companion object {
+        /**
+         * Represents a migration from version 2 to version 3 of the database schema.
+         * This migration adds a new column `htmlUrl` to the existing table.
+         */
+        val MIGRATION_2_TO_3 = object : Migration(2, 3) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                // Perform the necessary SQL operations to add the new column
+                database.execSQL("ALTER TABLE ${StringConstants.ROOM_DB_REPO_TABLE} ADD COLUMN htmlUrl TEXT")
+            }
+        }
+    }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/di/DatabaseModule.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/di/DatabaseModule.kt
@@ -34,7 +34,7 @@ object DatabaseModule {
             application,
             GitHubObjectsDatabase::class.java,
             StringConstants.ROOM_DB_REPO_TABLE
-        ).build()
+        ).addMigrations(GitHubObjectsDatabase.MIGRATION_2_TO_3).build()
     }
 
     /**
@@ -61,6 +61,6 @@ object DatabaseModule {
         application: Application,
         dao: GitHubObjectDao
     ): LocalGitHubRepository {
-        return LocalGitHubRepositoryImpl(application,dao)
+        return LocalGitHubRepositoryImpl(application, dao)
     }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/models/GitHubRepoObject.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/models/GitHubRepoObject.kt
@@ -53,7 +53,8 @@ fun GitHubRepoObject.toGitHubDataClass(): LocalGitHubRepoObject {
         forksCount = forksCount,
         openIssuesCount = openIssuesCount,
         avatarUrl = owner?.avatarUrl,
-        ownerType = owner?.type
+        ownerType = owner?.type,
+        htmlUrl = owner?.htmlUrl,
     )
 }
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/models/LocalGitHubRepoObject.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/models/LocalGitHubRepoObject.kt
@@ -26,6 +26,7 @@ data class LocalGitHubRepoObject(
     val id: Long,
     val name: String?,
     val avatarUrl: String?,
+    val htmlUrl: String?,
     val ownerType: String?,
     val language: String?,
     val stargazersCount: Long?,

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/models/MockObjects.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/models/MockObjects.kt
@@ -3,7 +3,11 @@ package jp.co.yumemi.android.code_check.models
 class MockObjects {
     companion object {
         private val mockOwnerObj =
-            Owner(avatarUrl = "https://avatars.githubusercontent.com/u/22025488?v=4", type = "User")
+            Owner(
+                avatarUrl = "https://avatars.githubusercontent.com/u/22025488?v=4",
+                htmlUrl = "https://github.com/charithvithanage",
+                type = "User"
+            )
         val mockGitHubRepoObject = GitHubRepoObject(
             id = 1,
             name = "charithvin",
@@ -17,7 +21,11 @@ class MockObjects {
         private val mockData = listOf(mockGitHubRepoObject)
 
         private val expectedOwnerObj =
-            Owner(avatarUrl = "https://avatars.githubusercontent.com/u/22025488?v=4", type = "User")
+            Owner(
+                avatarUrl = "https://avatars.githubusercontent.com/u/22025488?v=4",
+                htmlUrl = "https://github.com/charithvithanage",
+                type = "User"
+            )
         val expectedGitHubRepoObject = GitHubRepoObject(
             id = 1,
             name = "charithvin",
@@ -34,6 +42,7 @@ class MockObjects {
             id = 1,
             name = "charithvin",
             avatarUrl = "https://avatars.githubusercontent.com/u/22025488?v=4",
+            htmlUrl = "https://github.com/charithvithanage",
             ownerType = "User",
             language = "CSS",
             stargazersCount = 10,
@@ -47,6 +56,7 @@ class MockObjects {
             id = 1,
             name = "charithvin",
             avatarUrl = "https://avatars.githubusercontent.com/u/22025488?v=4",
+            htmlUrl = "https://github.com/charithvithanage",
             ownerType = "User",
             language = "CSS",
             stargazersCount = 10,

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/models/Owner.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/models/Owner.kt
@@ -9,9 +9,11 @@ import kotlinx.android.parcel.Parcelize
  *
  * @property avatarUrl The URL of the owner's avatar image.
  * @property type The type of the owner, e.g., "User" or "Organization."
+ * @property htmlUrl Owner's profile web link.
  */
 @Parcelize
 data class Owner(
     @SerializedName("avatar_url") val avatarUrl: String?,
+    @SerializedName("html_url") val htmlUrl: String?,
     val type: String?
 ) : Parcelable

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/activities/MainActivity.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/activities/MainActivity.kt
@@ -19,6 +19,7 @@ import jp.co.yumemi.android.code_check.constants.StringConstants.ACCOUNT_DETAILS
 import jp.co.yumemi.android.code_check.constants.StringConstants.FAVOURITE_FRAGMENT
 import jp.co.yumemi.android.code_check.constants.StringConstants.HOME_FRAGMENT
 import jp.co.yumemi.android.code_check.constants.StringConstants.SETTINGS_FRAGMENT
+import jp.co.yumemi.android.code_check.constants.StringConstants.WEB_PROFILE_VIEW_FRAGMENT
 import jp.co.yumemi.android.code_check.databinding.ActivityMainBinding
 import jp.co.yumemi.android.code_check.utils.LocalHelper
 import jp.co.yumemi.android.code_check.utils.UIUtils.Companion.updateMenuValues
@@ -123,6 +124,18 @@ class MainActivity : AppCompatActivity() {
                             LocalHelper.getString(
                                 this@MainActivity,
                                 R.string.details
+                            )
+                        )
+
+                    }
+
+                    WEB_PROFILE_VIEW_FRAGMENT -> {
+                        binding.btnBack.isVisible = true
+                        bottomNavView.isVisible = false
+                        setFragmentName(
+                            LocalHelper.getString(
+                                this@MainActivity,
+                                R.string.web_profile_view_details
                             )
                         )
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/fragments/repodetails/RepoDetailsFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/fragments/repodetails/RepoDetailsFragment.kt
@@ -13,7 +13,6 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
-import jp.co.yumemi.android.code_check.utils.LocalHelper
 import jp.co.yumemi.android.code_check.R
 import jp.co.yumemi.android.code_check.SingleLiveEvent.Companion.observeOnce
 import jp.co.yumemi.android.code_check.constants.DialogConstants
@@ -26,6 +25,7 @@ import jp.co.yumemi.android.code_check.models.LocalDBQueryResponse
 import jp.co.yumemi.android.code_check.ui.activities.MainActivityViewModel
 import jp.co.yumemi.android.code_check.utils.DialogUtils.Companion.showAlertDialogWithoutAction
 import jp.co.yumemi.android.code_check.utils.DialogUtils.Companion.showConfirmAlertDialog
+import jp.co.yumemi.android.code_check.utils.LocalHelper
 
 /**
  * Fragment that displays details of a GitHub repository and allows users to mark it as a favorite.
@@ -151,6 +151,11 @@ class RepoDetailsFragment : Fragment() {
                     )
                 }
 
+                btnMore.text = LocalHelper.getString(requireActivity(), R.string.view_more)
+                btnMore.setOnClickListener {
+                    navigateToWebProfileFragment()
+                }
+
             }
 
             setGitRepoData(gitHubRepo)
@@ -159,15 +164,30 @@ class RepoDetailsFragment : Fragment() {
         }
 
         //Handle back pressed event
-         object : OnBackPressedCallback(true) {
+        object : OnBackPressedCallback(true) {
             override fun handleOnBackPressed() {
                 findNavController().navigate(R.id.homeFragment)
                 // Handle back button press for Home Fragment
                 sharedViewModel.setFragment(HOME_FRAGMENT)
             }
         }.apply {
-             requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, this)
-         }
+            requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, this)
+        }
+    }
+
+    /**
+     * Navigates to the WebProfileViewFragment using the Navigation Component.
+     * If the owner's HTML URL is available, it constructs the appropriate navigation action.
+     * If the HTML URL is null, the navigation will not be performed.
+     */
+    private fun navigateToWebProfileFragment() {
+        findNavController().navigate(
+            gitHubRepo.owner?.htmlUrl.let {
+                RepoDetailsFragmentDirections.actionRepoDetailsFragmentToWebProfileViewFragment(
+                    it
+                )
+            }
+        )
     }
 
     /**

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/fragments/repodetails/RepoDetailsFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/fragments/repodetails/RepoDetailsFragment.kt
@@ -125,6 +125,20 @@ class RepoDetailsFragment : Fragment() {
     private fun initView() {
         viewModel.apply {
             binding.apply {
+
+                requireActivity().apply {
+                    //Update Report Details Resource values with localization
+                    updateUI(
+                        LocalHelper.getString(this, R.string.view_more),
+                        LocalHelper.getString(this, R.string.starts),
+                        LocalHelper.getString(this, R.string.forks),
+                        LocalHelper.getString(this, R.string.watchers),
+                        LocalHelper.getString(this, R.string.open_issues),
+                        LocalHelper.getString(this, R.string.language)
+                    )
+                }
+
+
                 btnFav.setOnClickListener {
                     val confirmationMessage = favouriteStatus.value?.let {
                         if (it) {
@@ -151,7 +165,6 @@ class RepoDetailsFragment : Fragment() {
                     )
                 }
 
-                btnMore.text = LocalHelper.getString(requireActivity(), R.string.view_more)
                 btnMore.setOnClickListener {
                     navigateToWebProfileFragment()
                 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/fragments/repodetails/RepoDetailsViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/fragments/repodetails/RepoDetailsViewModel.kt
@@ -23,6 +23,12 @@ import javax.inject.Inject
  * @property localDBResponse LiveData to observe responses from local database queries.
  * @property gitRepoData LiveData containing the selected GitHub repository's data.
  * @property favouriteStatus LiveData indicating the favourite status of the selected repository.
+ * @property btnValue LiveData indicating the text to be set on a button.
+ * @property startsLabel LiveData indicating the text to be set for the starts label.
+ * @property forksLabel LiveData indicating the text to be set for the forks label.
+ * @property watchersLabel LiveData indicating the text to be set for the watchers label.
+ * @property openIssuesLabel LiveData indicating the text to be set for the open issues label.
+ * @property language LiveData indicating the programming language associated with the repository.
  */
 @HiltViewModel
 class RepoDetailsViewModel @Inject constructor(private val localGitHubRepository: LocalGitHubRepository) :
@@ -38,6 +44,23 @@ class RepoDetailsViewModel @Inject constructor(private val localGitHubRepository
     private val _favouriteStatus = MutableLiveData(false)
     val favouriteStatus get() = _favouriteStatus
 
+    private val _btnValue = MutableLiveData<String>(null)
+    val btnValue get() = _btnValue
+
+    private val _startsLabel = MutableLiveData<String>(null)
+    val startsLabel get() = _startsLabel
+
+    private val _forksLabel = MutableLiveData<String>(null)
+    val forksLabel get() = _forksLabel
+
+    private val _watchersLabel = MutableLiveData<String>(null)
+    val watchersLabel get() = _watchersLabel
+
+    private val _openIssuesLabel = MutableLiveData<String>(null)
+    val openIssuesLabel get() = _openIssuesLabel
+
+    private val _languageString = MutableLiveData<String>(null)
+    val languageString get() = _languageString
 
     /**
      * Set the selected GitHub repository data to LiveData.
@@ -46,6 +69,35 @@ class RepoDetailsViewModel @Inject constructor(private val localGitHubRepository
      */
     fun setGitRepoData(gitHubRepo: GitHubRepoObject) {
         _gitRepoData.value = gitHubRepo
+    }
+
+    /**
+     * Updates the UI with the specified values.
+     *
+     * This function is responsible for updating various UI elements with the provided values,
+     * such as button text, start labels, forks labels, watchers labels, open issues labels, and language.
+     *
+     * @param btnValue The text to be set on a button.
+     * @param startsLabel The text to be set for the starts label.
+     * @param forksLabel The text to be set for the forks label.
+     * @param watchersLabel The text to be set for the watchers label.
+     * @param openIssuesLabel The text to be set for the open issues label.
+     * @param language The programming language associated with the repository.
+     */
+    fun updateUI(
+        btnValue: String,
+        startsLabel: String,
+        forksLabel: String,
+        watchersLabel: String,
+        openIssuesLabel: String,
+        language: String
+    ) {
+        _btnValue.value = btnValue
+        _startsLabel.value = startsLabel
+        _forksLabel.value = forksLabel
+        _watchersLabel.value = watchersLabel
+        _openIssuesLabel.value = openIssuesLabel
+        _languageString.value = "$language : ${gitRepoData.value?.language}"
     }
 
     /**

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/fragments/webprofileview/WebProfileViewFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/fragments/webprofileview/WebProfileViewFragment.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2021 YUMEMI Inc. All rights reserved.
+ */
+package jp.co.yumemi.android.code_check.ui.fragments.webprofileview
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProvider
+import androidx.navigation.fragment.navArgs
+import jp.co.yumemi.android.code_check.constants.StringConstants
+import jp.co.yumemi.android.code_check.databinding.FragmentWebProfileViewBinding
+import jp.co.yumemi.android.code_check.ui.activities.MainActivityViewModel
+
+/**
+ * WebProfileViewFragment responsible for displaying a web profile view.
+ *
+ * This Fragment is used to show a web page specified by the provided HTML URL.
+ * It assumes the presence of a WebView in the associated layout with the ID 'webView'.
+ *
+ * @property args Arguments received through Safe Args for navigation
+ * @property binding View binding for this Fragment
+ * @property htmlUrl HTML URL to be displayed in the WebView
+ * @property sharedViewModel Shared ViewModel with the main activity
+ */
+class WebProfileViewFragment : Fragment() {
+    private val args: WebProfileViewFragmentArgs by navArgs()
+    private lateinit var binding: FragmentWebProfileViewBinding
+    private var htmlUrl: String? = null
+    private lateinit var sharedViewModel: MainActivityViewModel
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        // Safe Args: Retrieve the HTML URL from the navigation arguments
+        htmlUrl = args.htmlUrl
+        FragmentWebProfileViewBinding.inflate(inflater, container, false).apply {
+            binding = this
+            lifecycleOwner = this@WebProfileViewFragment
+            // Configure the WebView
+            webView.run {
+                settings.javaScriptEnabled = true
+                settings.loadWithOverviewMode = true
+                settings.useWideViewPort = true
+
+                // Load the Git Hub User Profile HTML URL in the WebView
+                htmlUrl?.let { loadUrl(it) }
+            }
+        }
+
+        // Initialize the shared ViewModel with the main activity
+        sharedViewModel =
+            ViewModelProvider(requireActivity())[MainActivityViewModel::class.java]
+        sharedViewModel.setFragment(StringConstants.WEB_PROFILE_VIEW_FRAGMENT)
+
+        return binding.root
+    }
+}

--- a/app/src/main/res/layout-land/fragment_repo_details.xml
+++ b/app/src/main/res/layout-land/fragment_repo_details.xml
@@ -77,7 +77,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/content_margin_top"
-                android:text='@{"Language : "+vm.gitRepoData.language}'
+                android:text='@{vm.languageString}'
                 app:layout_constraintEnd_toEndOf="@+id/nameView"
                 app:layout_constraintStart_toStartOf="@+id/nameView"
                 app:layout_constraintTop_toBottomOf="@+id/nameView" />
@@ -87,7 +87,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/content_margin_top"
-                android:text="@string/view_more"
+                android:text="@{vm.btnValue}"
                 app:layout_constraintEnd_toEndOf="@+id/languageView"
                 app:layout_constraintStart_toStartOf="@+id/languageView"
                 app:layout_constraintTop_toBottomOf="@+id/languageView" />
@@ -114,7 +114,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="match_parent"
                         android:layout_weight="1"
-                        bind:label='@{"Starts"}'
+                        bind:label='@{vm.startsLabel}'
                         bind:value="@{vm.gitRepoData.stargazersCount.toString()}" />
 
                     <include
@@ -123,7 +123,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="match_parent"
                         android:layout_weight="1"
-                        bind:label='@{"Watchers"}'
+                        bind:label='@{vm.watchersLabel}'
                         bind:value="@{vm.gitRepoData.watchersCount.toString()}" />
                 </LinearLayout>
 
@@ -139,7 +139,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="match_parent"
                         android:layout_weight="1"
-                        bind:label='@{"Forks"}'
+                        bind:label='@{vm.forksLabel}'
                         bind:value="@{vm.gitRepoData.forksCount.toString()}" />
 
 
@@ -149,7 +149,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="match_parent"
                         android:layout_weight="1"
-                        bind:label='@{"Open Issues"}'
+                        bind:label='@{vm.openIssuesLabel}'
                         bind:value="@{vm.gitRepoData.openIssuesCount.toString()}" />
                 </LinearLayout>
             </LinearLayout>

--- a/app/src/main/res/layout-land/fragment_repo_details.xml
+++ b/app/src/main/res/layout-land/fragment_repo_details.xml
@@ -36,22 +36,35 @@
                 android:id="@+id/ownerIconView"
                 android:layout_width="0dp"
                 android:layout_height="0dp"
-                android:layout_marginStart="50dp"
-                android:layout_marginEnd="50dp"
+                android:layout_marginTop="@dimen/page_padding"
                 android:contentDescription="@null"
                 app:imageUrl="@{vm.gitRepoData.owner.avatarUrl}"
                 app:layout_constraintDimensionRatio="1:1"
-                app:layout_constraintEnd_toStartOf="@+id/imageSectionHorizontalGuide"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/btnFav"
+                app:layout_constraintEnd_toStartOf="@+id/imageSectionHorizontalGuide2"
+                app:layout_constraintStart_toStartOf="@+id/imageSectionHorizontalGuide1"
+                app:layout_constraintTop_toTopOf="parent"
                 app:shapeAppearanceOverlay="@style/roundedImageViewRounded" />
+
+            <androidx.constraintlayout.widget.Guideline
+                android:id="@+id/imageSectionHorizontalGuide1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                app:layout_constraintGuide_percent="0.10" />
+
+            <androidx.constraintlayout.widget.Guideline
+                android:id="@+id/imageSectionHorizontalGuide2"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                app:layout_constraintGuide_percent="0.30" />
 
             <TextView
                 android:id="@+id/nameView"
                 style="@style/nameTextViewStyle"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/vertical_margin"
+                android:layout_marginTop="@dimen/content_margin_top"
                 android:gravity="center"
                 android:text='@{vm.gitRepoData.name}'
                 app:layout_constraintEnd_toEndOf="@+id/ownerIconView"
@@ -64,11 +77,20 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/content_margin_top"
-                android:paddingBottom="@dimen/page_padding"
                 android:text='@{"Language : "+vm.gitRepoData.language}'
                 app:layout_constraintEnd_toEndOf="@+id/nameView"
                 app:layout_constraintStart_toStartOf="@+id/nameView"
                 app:layout_constraintTop_toBottomOf="@+id/nameView" />
+
+            <Button
+                android:id="@+id/btnMore"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/content_margin_top"
+                android:text="@string/view_more"
+                app:layout_constraintEnd_toEndOf="@+id/languageView"
+                app:layout_constraintStart_toStartOf="@+id/languageView"
+                app:layout_constraintTop_toBottomOf="@+id/languageView" />
 
 
             <LinearLayout
@@ -138,7 +160,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
-                app:layout_constraintGuide_percent="0.30" />
+                app:layout_constraintGuide_percent="0.40" />
 
             <androidx.constraintlayout.widget.Guideline
                 android:id="@+id/centerHorizontalGuid"
@@ -147,12 +169,6 @@
                 android:orientation="horizontal"
                 app:layout_constraintGuide_percent="0.50" />
 
-            <androidx.constraintlayout.widget.Guideline
-                android:id="@+id/contentVerticalCenterGuid"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:orientation="vertical"
-                app:layout_constraintGuide_percent="0.7" />
         </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>
 </layout>

--- a/app/src/main/res/layout/fragment_repo_details.xml
+++ b/app/src/main/res/layout/fragment_repo_details.xml
@@ -61,7 +61,7 @@
             android:layout_marginHorizontal="@dimen/horizontal_margin"
             android:layout_marginStart="@dimen/page_padding"
             android:layout_marginEnd="@dimen/page_padding"
-            android:text='@{"Language : "+vm.gitRepoData.language}'
+            android:text='@{vm.languageString}'
             app:layout_constraintBottom_toTopOf="@+id/btnMore"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent" />
@@ -70,7 +70,7 @@
             android:id="@+id/btnMore"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/view_more"
+            android:text="@{vm.btnValue}"
             app:layout_constraintBottom_toTopOf="@+id/centerHorizontalGuid"
             app:layout_constraintEnd_toEndOf="@+id/languageView"
             app:layout_constraintStart_toStartOf="@+id/languageView" />
@@ -92,7 +92,7 @@
             app:layout_constraintEnd_toStartOf="@+id/centerVerticalGuid"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="@+id/centerHorizontalGuid"
-            bind:label='@{"Starts"}'
+            bind:label='@{vm.startsLabel}'
             bind:value="@{vm.gitRepoData.stargazersCount.toString()}" />
 
         <include
@@ -103,7 +103,7 @@
             app:layout_constraintEnd_toStartOf="@+id/centerVerticalGuid"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/include2"
-            bind:label='@{"Forks"}'
+            bind:label='@{vm.forksLabel}'
             bind:value="@{vm.gitRepoData.forksCount.toString()}" />
 
         <include
@@ -116,7 +116,7 @@
             app:layout_constraintStart_toStartOf="@+id/centerVerticalGuid"
             app:layout_constraintTop_toBottomOf="@+id/include2"
             app:layout_constraintTop_toTopOf="@+id/include2"
-            bind:label='@{"Watchers"}'
+            bind:label='@{vm.watchersLabel}'
             bind:value="@{vm.gitRepoData.watchersCount.toString()}" />
 
         <include
@@ -127,7 +127,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="@+id/centerVerticalGuid"
             app:layout_constraintTop_toBottomOf="@+id/include"
-            bind:label='@{"Open Issues"}'
+            bind:label='@{vm.openIssuesLabel}'
             bind:value="@{vm.gitRepoData.openIssuesCount.toString()}" />
 
 

--- a/app/src/main/res/layout/fragment_repo_details.xml
+++ b/app/src/main/res/layout/fragment_repo_details.xml
@@ -20,7 +20,7 @@
             android:layout_margin="@dimen/avatar_margin"
             android:contentDescription="@null"
             app:imageUrl="@{vm.gitRepoData.owner.avatarUrl}"
-            app:layout_constraintBottom_toBottomOf="@id/imageSectionGuide"
+            app:layout_constraintBottom_toTopOf="@id/nameView"
             app:layout_constraintDimensionRatio="1:1"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -49,10 +49,9 @@
             android:layout_marginEnd="@dimen/page_padding"
             android:gravity="center"
             android:text='@{vm.gitRepoData.name}'
-            app:layout_constraintBottom_toTopOf="@+id/centerHorizontalGuid"
+            app:layout_constraintBottom_toTopOf="@+id/languageView"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/ownerIconView" />
+            app:layout_constraintStart_toStartOf="parent" />
 
         <TextView
             android:id="@+id/languageView"
@@ -63,9 +62,18 @@
             android:layout_marginStart="@dimen/page_padding"
             android:layout_marginEnd="@dimen/page_padding"
             android:text='@{"Language : "+vm.gitRepoData.language}'
+            app:layout_constraintBottom_toTopOf="@+id/btnMore"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/nameView" />
+            app:layout_constraintStart_toStartOf="parent" />
+
+        <Button
+            android:id="@+id/btnMore"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/view_more"
+            app:layout_constraintBottom_toTopOf="@+id/centerHorizontalGuid"
+            app:layout_constraintEnd_toEndOf="@+id/languageView"
+            app:layout_constraintStart_toStartOf="@+id/languageView" />
 
         <androidx.constraintlayout.widget.Guideline
             android:id="@+id/centerVerticalGuid"
@@ -122,13 +130,6 @@
             bind:label='@{"Open Issues"}'
             bind:value="@{vm.gitRepoData.openIssuesCount.toString()}" />
 
-
-        <androidx.constraintlayout.widget.Guideline
-            android:id="@+id/imageSectionGuide"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            app:layout_constraintGuide_percent="0.40" />
 
         <androidx.constraintlayout.widget.Guideline
             android:id="@+id/centerHorizontalGuid"

--- a/app/src/main/res/layout/fragment_web_profile_view.xml
+++ b/app/src/main/res/layout/fragment_web_profile_view.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+        <WebView
+            android:id="@+id/webView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -17,6 +17,18 @@
     </fragment>
 
     <fragment
+        android:id="@+id/webProfileViewFragment"
+        android:name="jp.co.yumemi.android.code_check.ui.fragments.webprofileview.WebProfileViewFragment"
+        android:label="@string/web_profile_view_details"
+        tools:layout="@layout/fragment_web_profile_view">
+
+        <argument
+            android:name="htmlUrl"
+            app:argType="string"
+            app:nullable="true" />
+    </fragment>
+
+    <fragment
         android:id="@+id/repoDetailsFragment"
         android:name="jp.co.yumemi.android.code_check.ui.fragments.repodetails.RepoDetailsFragment"
         android:label="@string/details"
@@ -27,7 +39,11 @@
         <argument
             android:name="isFavourite"
             app:argType="boolean" />
+        <action
+            android:id="@+id/action_repoDetailsFragment_to_webProfileViewFragment"
+            app:destination="@id/webProfileViewFragment" />
     </fragment>
+
     <fragment
         android:id="@+id/settingsFragment"
         android:name="jp.co.yumemi.android.code_check.ui.fragments.settings.SettingsFragment"

--- a/app/src/main/res/values-ja-ldltr/strings.xml
+++ b/app/src/main/res/values-ja-ldltr/strings.xml
@@ -35,4 +35,5 @@
     <string name="data_already_exist">データはすでに存在します</string>
     <string name="add_fav_success_message">アカウントがお気に入りに追加されました</string>
     <string name="delete_fav_success_message">アカウントがお気に入りから削除されました</string>
+    <string name="view_more">もっと見る</string>
 </resources>

--- a/app/src/main/res/values-ja-ldltr/strings.xml
+++ b/app/src/main/res/values-ja-ldltr/strings.xml
@@ -36,4 +36,5 @@
     <string name="add_fav_success_message">アカウントがお気に入りに追加されました</string>
     <string name="delete_fav_success_message">アカウントがお気に入りから削除されました</string>
     <string name="view_more">もっと見る</string>
+    <string name="web_profile_view_details">ウェブプロフィール</string>
 </resources>

--- a/app/src/main/res/values-ja-ldltr/strings.xml
+++ b/app/src/main/res/values-ja-ldltr/strings.xml
@@ -37,4 +37,9 @@
     <string name="delete_fav_success_message">アカウントがお気に入りから削除されました</string>
     <string name="view_more">もっと見る</string>
     <string name="web_profile_view_details">ウェブプロフィール</string>
+    <string name="starts">スタート</string>
+    <string name="forks">フォーク</string>
+    <string name="watchers">監視者</string>
+    <string name="open_issues">公開されていない問題</string>
+    <string name="language">プログラミング言語</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,6 +34,7 @@
     <string name="radio_button_custom_icon">Radio Button Icon</string>
     <string name="search_input_empty_error">Please enter value before submit</string>
     <string name="no_internet">No Internet</string>
+    <string name="view_more">View More</string>
 
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,7 +35,14 @@
     <string name="radio_button_custom_icon">Radio Button Icon</string>
     <string name="search_input_empty_error">Please enter value before submit</string>
     <string name="no_internet">No Internet</string>
+
+    <!-- Details Page Resource Values -->
     <string name="view_more">View More</string>
+    <string name="starts">Starts</string>
+    <string name="forks">Forks</string>
+    <string name="watchers">Watchers</string>
+    <string name="open_issues">Open Issues</string>
+    <string name="language">Language</string>
 
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="menu_favourites">Favourites</string>
     <string name="menu_settings">Settings</string>
     <string name="details">Details</string>
+    <string name="web_profile_view_details">Web Profile</string>
     <string name="select_app_language">App Language</string>
 
     <!-- Dialog messages -->


### PR DESCRIPTION
## Pull Request Summary

This pull request introduces a new Web Profile View Fragment as the main feature

#### 1). New Fragment: Web Profile View Fragment

- Created a new fragment dedicated to viewing Github User's web profile.
- Added htmlUrl to Owner.kt to retrieve the profile URL.

#### 2). Migration Script for Local Room DB

- Wrote a migration script to add a new column to the local Room database's repository table.
#### 3). Repo Details Page Enhancement

- Added a "View More" button to the Repo Details page for improved user interaction.

- Localized fields in RepoDetailsFragment.kt using LiveData for enhanced support and user experience.
#### 4). New UI Test Case and Test Case Adjustments

- Implemented UI test cases for the newly added Web Profile View Fragment to ensure robust functionality.

- Updated the testNavigateToFavouriteWithSavedGitHubList test class in FavouritesFragmentTest.kt to accommodate changes due to library updates.
## Screenshots and Video

https://github.com/charithgtp01/android-engineer-codecheck/assets/116966432/f7c707fe-b1b7-42f1-a764-2567f40f1c24


![repo_details_fragment](https://github.com/charithgtp01/android-engineer-codecheck/assets/116966432/aef9732b-003c-48ad-a520-ca101ba31ce6)
![web_view_fragment](https://github.com/charithgtp01/android-engineer-codecheck/assets/116966432/eea6addb-82d3-4cda-bc1d-d5ed65e16289)
